### PR TITLE
Remove "Do Not Redistribute"

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -3,8 +3,6 @@
 # Recipe:: default
 #
 # Copyright (C) 2013 Brian Akins
-# 
-# All rights reserved - Do Not Redistribute
 #
 
 include_recipe "apt"


### PR DESCRIPTION
Because the chosen license is Apache, having that line is a little confusing.
